### PR TITLE
feat(login): 错误处理

### DIFF
--- a/api/common/perr/errCode.go
+++ b/api/common/perr/errCode.go
@@ -1,0 +1,16 @@
+package perr
+
+// OK 成功
+const OK uint32 = 200
+
+// 全局错误码
+const (
+	ServerCommonError  uint32 = 10001
+	TokenGenerateError uint32 = 10002
+	DBError            uint32 = 10003
+)
+
+// 登录模块
+const (
+	ErrAuthCodeError uint32 = 20001
+)

--- a/api/common/perr/errMsg.go
+++ b/api/common/perr/errMsg.go
@@ -1,0 +1,28 @@
+package perr
+
+var message map[uint32]string
+
+func init() {
+	message = make(map[uint32]string)
+	message[OK] = "Success"
+	message[ServerCommonError] = "服务器开小差啦，稍后再来试一试吧"
+	message[TokenGenerateError] = "生成token失败"
+	message[ErrAuthCodeError] = "验证码错误"
+	message[DBError] = "数据库繁忙，请稍后再试"
+}
+
+func MapErrMsg(errCode uint32) string {
+	if msg, ok := message[errCode]; ok {
+		return msg
+	} else {
+		return "服务器开小差啦，稍后再来试一试吧"
+	}
+}
+
+func IsCodeErr(errCode uint32) bool {
+	if _, ok := message[errCode]; ok {
+		return true
+	} else {
+		return false
+	}
+}

--- a/api/common/perr/errors.go
+++ b/api/common/perr/errors.go
@@ -1,0 +1,36 @@
+package perr
+
+import (
+	"fmt"
+)
+
+/**
+常用通用固定错误
+*/
+
+type CodeError struct {
+	errCode uint32
+	errMsg  string
+}
+
+// GetErrCode 返回给前端的错误码
+func (e *CodeError) GetErrCode() uint32 {
+	return e.errCode
+}
+
+// GetErrMsg 返回给前端显示端错误信息
+func (e *CodeError) GetErrMsg() string {
+	return e.errMsg
+}
+
+func (e *CodeError) Error() string {
+	return fmt.Sprintf("ErrCode:%d，ErrMsg:%s", e.errCode, e.errMsg)
+}
+
+func NewErrCode(errCode uint32) *CodeError {
+	return &CodeError{errCode: errCode, errMsg: MapErrMsg(errCode)}
+}
+
+func NewErrMsg(errMsg string) *CodeError {
+	return &CodeError{errCode: ServerCommonError, errMsg: errMsg}
+}

--- a/api/common/result/httpResult.go
+++ b/api/common/result/httpResult.go
@@ -1,0 +1,32 @@
+package result
+
+import (
+	"github.com/minibear2333/programmer-go/api/common/perr"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/zeromicro/go-zero/core/logx"
+	"github.com/zeromicro/go-zero/rest/httpx"
+)
+
+// HttpResult http返回
+func HttpResult(r *http.Request, w http.ResponseWriter, resp interface{}, err error) {
+	if err == nil {
+		// 成功返回
+		r := Success(resp)
+		httpx.WriteJson(w, http.StatusOK, r)
+	} else {
+		// 错误返回
+		errcode := perr.ServerCommonError
+		errmsg := "服务器开小差啦，稍后再来试一试"
+
+		causeErr := errors.Cause(err)                // err类型
+		if e, ok := causeErr.(*perr.CodeError); ok { // 自定义错误类型
+			//自定义 CodeError
+			errcode = e.GetErrCode()
+			errmsg = e.GetErrMsg()
+		}
+		logx.WithContext(r.Context()).Errorf("【API-ERR】 : %+v ", err)
+		httpx.WriteJson(w, http.StatusBadRequest, Error(errcode, errmsg))
+	}
+}

--- a/api/common/result/response.go
+++ b/api/common/result/response.go
@@ -1,0 +1,20 @@
+package result
+
+type ResponseSuccess struct {
+	Code uint32      `json:"code"`
+	Msg  string      `json:"msg"`
+	Data interface{} `json:"data"`
+}
+
+type ResponseError struct {
+	Code uint32 `json:"code"`
+	Msg  string `json:"msg"`
+}
+
+func Success(data interface{}) *ResponseSuccess {
+	return &ResponseSuccess{200, "OK", data}
+}
+
+func Error(errCode uint32, errMsg string) *ResponseError {
+	return &ResponseError{errCode, errMsg}
+}

--- a/api/go.mod
+++ b/api/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/natefinch/lumberjack v2.0.0+incompatible
+	github.com/pkg/errors v0.9.1
 	github.com/zeromicro/go-zero v1.3.1
 	go.uber.org/zap v1.21.0
 )

--- a/api/internal/handler/login/loginhandler.go
+++ b/api/internal/handler/login/loginhandler.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"github.com/minibear2333/programmer-go/api/common/result"
 	"net/http"
 
 	"github.com/minibear2333/programmer-go/api/internal/logic/login"
@@ -19,10 +20,6 @@ func LoginHandler(svcCtx *svc.ServiceContext) http.HandlerFunc {
 
 		l := login.NewLoginLogic(r.Context(), svcCtx)
 		resp, err := l.Login(req)
-		if err != nil {
-			httpx.Error(w, err)
-		} else {
-			httpx.OkJson(w, resp)
-		}
+		result.HttpResult(r, w, resp, err)
 	}
 }

--- a/api/internal/logic/login/loginlogic.go
+++ b/api/internal/logic/login/loginlogic.go
@@ -2,12 +2,13 @@ package login
 
 import (
 	"context"
-	"errors"
+	"github.com/minibear2333/programmer-go/api/common/perr"
 	"github.com/minibear2333/programmer-go/api/global"
 	"github.com/minibear2333/programmer-go/api/internal/svc"
 	"github.com/minibear2333/programmer-go/api/internal/types"
 	"github.com/minibear2333/programmer-go/api/model"
 	"github.com/minibear2333/programmer-go/api/utils"
+	"github.com/pkg/errors"
 	"github.com/zeromicro/go-zero/core/logx"
 	"go.uber.org/zap"
 	"strings"
@@ -19,6 +20,8 @@ type LoginLogic struct {
 	ctx    context.Context
 	svcCtx *svc.ServiceContext
 }
+
+var ErrAuthCodeError = perr.NewErrMsg("验证码错误")
 
 func NewLoginLogic(ctx context.Context, svcCtx *svc.ServiceContext) LoginLogic {
 	return LoginLogic{
@@ -32,14 +35,14 @@ func (l *LoginLogic) Login(req types.ReqLogin) (resp *types.RespLogin, err error
 	// 获取 openId
 	openId := global.REDIS.HGet(context.Background(), req.ValiCode, "openid").Val()
 	if len(strings.TrimSpace(openId)) == 0 {
-		return nil, errors.New("验证码错误")
+		return nil, errors.Wrap(ErrAuthCodeError, "验证码错误")
 	}
 
 	// 登录逻辑
 	user, err := global.Mongo.UserModel.FindOneByOpenId(context.TODO(), openId)
 	if err != nil && err != model.ErrNotFound {
 		global.LOG.Error("根据 OpenId 获取用户失败", zap.Error(err))
-		return nil, errors.New("未知错误")
+		return nil, errors.Wrapf(perr.NewErrCode(perr.DBError), "根据OpenId获取用户失败，OpenId: %s", openId)
 	}
 
 	if user == nil {
@@ -47,6 +50,7 @@ func (l *LoginLogic) Login(req types.ReqLogin) (resp *types.RespLogin, err error
 		defaultUser := getDefaultUser(openId)
 		if err := global.Mongo.UserModel.Insert(context.TODO(), &defaultUser); err != nil {
 			global.LOG.Error("创建用户失败!", zap.Error(err))
+			return nil, perr.NewErrCode(perr.ServerCommonError)
 		}
 		user = &defaultUser
 	}
@@ -61,7 +65,7 @@ func (l *LoginLogic) Login(req types.ReqLogin) (resp *types.RespLogin, err error
 	token, err := j.CreateToken(claims)
 	if err != nil {
 		global.LOG.Error("获取token失败!", zap.Error(err))
-		return
+		return nil, errors.Wrapf(perr.NewErrCode(perr.TokenGenerateError), "IdentityRpc.GenerateToken userId : %s", user.ID.Hex())
 	}
 
 	return &types.RespLogin{


### PR DESCRIPTION
错误处理底层使用标准库的 errors.Wrapf，因此我们业务中返回错误都适用于 errors，但是推荐使用我们 perr 定义错误。因为在项目迭代，使用 rpc 后，rpc 的返回的错误我们可以自定义重写，返回给前端错误信息。默认返回错误：服务器开小差了。
目前在 login 模块已经使用了错误码封装。错误处理后，自动日志上报未完成。错误已经可以打印到 console。